### PR TITLE
About 페이지 로고 우측 최소 여백을 추가한다.

### DIFF
--- a/src/pages/About/AboutPage.style.js
+++ b/src/pages/About/AboutPage.style.js
@@ -127,11 +127,12 @@ const S = {
     height: 100%;
     max-height: 7.97rem;
     box-sizing: border-box;
-
+    margin-right: 3rem;
     @media (max-width: 1279px) {
       box-sizing: border-box;
       padding: 0 1.5rem;
       margin-left: 0;
+      margin-right: 0;
       margin-bottom: 5rem;
     }
   `,


### PR DESCRIPTION
# 구현 기능
- About 페이지 로고 우측 최소 여백을 추가한다.

# 구현 상태
![image](https://github.com/user-attachments/assets/d4c5a5d4-5091-40d5-97ec-037b29e856b0)
