### PR TITLE
EPRians 페이지 멤버 정렬 순서를 수정한다.

### DIFF
--- a/src/components/EPRians/Dropdown.jsx
+++ b/src/components/EPRians/Dropdown.jsx
@@ -18,11 +18,7 @@ const Dropdown = ({ className, options, setAlumniList }) => {
     const getAlumniList = async () => {
       try {
         const res = await getMembersAlumni(gen);
-        setAlumniList(
-          res.sort((a, b) => {
-            return a.name.localeCompare(b.name);
-          }),
-        );
+        setAlumniList(res);
       } catch (err) {
         console.error(err);
       }

--- a/src/pages/EPRians/EPRiansPage.jsx
+++ b/src/pages/EPRians/EPRiansPage.jsx
@@ -68,14 +68,14 @@ const EPRiansPage = () => {
             return numB - numA; // 내림차순 정렬
           });
 
+        const sortedActingRes = actingRes.sort((a, b) => {
+          return parseInt(a.num) - parseInt(b.num); //기수 빠른 순 정렬
+        });
+
         // 데이터 설정
         setGenList(sortedGen);
         setExecutiveList(executiveRes);
-        setActingList(
-          actingRes.sort((a, b) => {
-            return a.name.localeCompare(b.name);
-          }),
-        );
+        setActingList(sortedActingRes);
         setBrandList(brandRes);
         setGen(classRes.num);
       } catch (err) {


### PR DESCRIPTION
# 구현 기능
- EPRians 페이지 멤버 정렬 순서를 수정한다.

# 구현 상태
- 운영진 순서 : 학회장-기획부장-운영부장-홍보부장 순서 고정 (서버 response 그대로)
- 활동 학회원 : 기수 빠른 순으로 정렬. 같은 기수 내에서는 입력 순서대로
- 수료 학회원 : 입력 순서대로 정렬

# 리뷰 요청사항
